### PR TITLE
feat(yprox.app-docker:mariadb): add mariadb.init to generate SQL that will be executed by the container when building

### DIFF
--- a/yprox.app-docker/.manala.yaml
+++ b/yprox.app-docker/.manala.yaml
@@ -26,6 +26,8 @@ system:
         # @option {"label": "MariaDB version"}
         # @schema {"enum": [null, 10.5, 10.4, 10.3, 10.2, 10.1, "10.0"]}
         version: ~
+        # @schema {"type": ["array"]}
+        init: []
     postgresql:
         # @option {"label": "PostgreSQL version"}
         # @schema {"enum": [null, 13, 12, 11, 10, 9.6]}

--- a/yprox.app-docker/.manala.yaml
+++ b/yprox.app-docker/.manala.yaml
@@ -26,8 +26,8 @@ system:
         # @option {"label": "MariaDB version"}
         # @schema {"enum": [null, 10.5, 10.4, 10.3, 10.2, 10.1, "10.0"]}
         version: ~
-        # @schema {"type": ["array"]}
-        init: []
+        # @schema {"type": ["string", "null"]}
+        init: ~
     postgresql:
         # @option {"label": "PostgreSQL version"}
         # @schema {"enum": [null, 13, 12, 11, 10, 9.6]}

--- a/yprox.app-docker/.manala.yaml.tmpl
+++ b/yprox.app-docker/.manala.yaml.tmpl
@@ -33,9 +33,9 @@ system:
     {{- if .mariadb.version }}
     mariadb:
         version: {{ .mariadb.version | toYaml }}
-        init:
-            - 'CREATE DATABASE IF NOT EXISTS `app_test`;'
-            - 'GRANT ALL ON `app_test`.* TO 'app'@'%';
+        init: |
+            CREATE DATABASE IF NOT EXISTS `app_test`;
+            GRANT ALL ON `app_test`.* TO 'app'@'%';
     {{- end }}
 
     {{- if .postgresql.version }}

--- a/yprox.app-docker/.manala.yaml.tmpl
+++ b/yprox.app-docker/.manala.yaml.tmpl
@@ -33,6 +33,9 @@ system:
     {{- if .mariadb.version }}
     mariadb:
         version: {{ .mariadb.version | toYaml }}
+        init:
+            - 'CREATE DATABASE IF NOT EXISTS `app_test`;'
+            - 'GRANT ALL ON `app_test`.* TO 'app'@'%';
     {{- end }}
 
     {{- if .postgresql.version }}

--- a/yprox.app-docker/.manala/init-db/01.sql.tmpl
+++ b/yprox.app-docker/.manala/init-db/01.sql.tmpl
@@ -1,3 +1,3 @@
-{{- range .Vars.system.mariadb.init -}}
-{{- . }}
-{{ end }}
+{{- if .Vars.system.mariadb.init -}}
+{{- .Vars.system.mariadb.init -}}
+{{- end -}}

--- a/yprox.app-docker/.manala/init-db/01.sql.tmpl
+++ b/yprox.app-docker/.manala/init-db/01.sql.tmpl
@@ -1,0 +1,3 @@
+{{- range .Vars.system.mariadb.init -}}
+{{- . }}
+{{ end }}

--- a/yprox.app-docker/docker-compose.yaml.tmpl
+++ b/yprox.app-docker/docker-compose.yaml.tmpl
@@ -62,6 +62,7 @@ services:
       TZ: {{ .Vars.system.timezone }}
     volumes:
       - db-data:/var/lib/mysql
+      - .manala/init-db:/docker-entrypoint-initdb.d
     healthcheck:
       test: mysqladmin ping --silent
       interval: 10s


### PR DESCRIPTION
Example usage:

```yaml
system:
    # ...
    mariadb:
        version: 10.5
        init: |
            CREATE DATABASE IF NOT EXISTS `app_test`;
            GRANT ALL ON `app_test`.* TO 'app'@'%';
```

Will automatically generates a `.manala/init-db/01.sql` file containing:
```sql
CREATE DATABASE IF NOT EXISTS `app_test`;
GRANT ALL ON `app_test`.* TO 'app'@'%';
```

And volume `.manala/init-db` is mount to `/docker-entrypoint-initdb.d`.