### PR TITLE
feat(yprox.app-docker): wait for database to be ready when booting containers

### DIFF
--- a/yprox.app-docker/.manala/Makefile.tmpl
+++ b/yprox.app-docker/.manala/Makefile.tmpl
@@ -1,3 +1,8 @@
+{{- $has_postgresql := .Vars.system.postgresql.version -}}
+{{- $has_mariadb := .Vars.system.mariadb.version -}}
+{{- $has_mysql := .Vars.system.mysql.version -}}
+{{- $has_redis := .Vars.system.redis.version -}}
+
 # Relative root dir ("."|".."|"../.."|…)
 _ROOT_DIR := $(patsubst ./%,%,$(patsubst %/.manala/Makefile,%,./$(filter %.manala/Makefile,$(MAKEFILE_LIST))))
 # Is current dir root ? (""|"1")
@@ -52,8 +57,17 @@ setup-domain:
 
 _up:
 	$(dc) up --detach
-	{{- if or (.Vars.system.postgresql.version) (.Vars.system.mariadb.version) (.Vars.system.mysql.version) }} database{{ end }}
-	{{- if .Vars.system.redis.version }} redis{{ end }}
+	{{- if or ($has_postgresql) ($has_mariadb) ($has_mysql) }} database{{ end }}
+	{{- if $has_redis }} redis{{ end }}
+
+	{{ if or ($has_postgresql) ($has_mariadb) ($has_mysql) -}}
+	@$(call message_warning, Waiting for the database to be ready...)
+	@until docker inspect -f {{ "{{.State.Health.Status}}" }} `$(dc) ps -q database` | grep -q "healthy"; do \
+      $(call message_warning, Waiting...); \
+      sleep 1; \
+	done
+	@$(call message_success, The database is ready!)
+	{{- end }}
 
 HELP += $(call help,up,                Start the development environment)
 up:
@@ -75,7 +89,7 @@ destroy: halt
 
 HELP += $(call help_section, Development tools)
 
-{{- if .Vars.system.postgresql.version -}}
+{{- if $has_postgresql -}}
 HELP += $(call help,run-phppgadmin,    Start a PhpPgAdmin web interface)
 run-phppgadmin:
 	$(dc) up --detach phppgadmin
@@ -84,7 +98,7 @@ run-phppgadmin:
 	@echo
 {{- end }}
 
-{{ if .Vars.system.mariadb.version -}}
+{{ if or ($has_mariadb) ($has_mysql) -}}
 HELP += $(call help,run-phpmyadmin,    Start a PhpMyAdmin web interface)
 run-phpmyadmin:
 	$(dc) up --detach phpmyadmin
@@ -93,7 +107,7 @@ run-phpmyadmin:
 	@echo
 {{- end }}
 
-{{ if .Vars.system.redis.version -}}
+{{ if $has_redis -}}
 HELP += $(call help,run-phpredisadmin, Start a PhpRedisAdmin web interface)
 run-phpredisadmin:
 	$(dc) up --detach phpredisadmin

--- a/yprox.app-docker/.manala/make/text.mk
+++ b/yprox.app-docker/.manala/make/text.mk
@@ -47,7 +47,7 @@ define message_success
 endef
 
 define message_warning
-	printf "$(COLOR_WARNING)¯\_(ツ)_/¯ $(strip $(1))$(COLOR_RESET)\n"
+	printf "$(COLOR_WARNING)$(strip $(1))$(COLOR_RESET)\n"
 endef
 
 define message_error


### PR DESCRIPTION
Following of 5e356b6a28a175410864d186d807b89881fe6632.

When creating containers for the first time (e.g.: `make setup`), the database can be not ready yet before we try to using it.

Now when running `make setup` or `make up` (any tasks which use task `_up` in fact), we will wait for the database to be 100% ready.

Before:
![image](https://user-images.githubusercontent.com/2103975/115672480-e41e5580-a34b-11eb-9e92-a8261cda781e.png)

After:
![image](https://user-images.githubusercontent.com/2103975/115672608-044e1480-a34c-11eb-8661-f011726214f1.png)
