### PR TITLE
fix(yprox.app-docker): run the symfony proxy when running `make up`

### DIFF
--- a/yprox.app-docker/.manala/Makefile.tmpl
+++ b/yprox.app-docker/.manala/Makefile.tmpl
@@ -72,6 +72,7 @@ _up:
 HELP += $(call help,up,                Start the development environment)
 up:
 	$(MAKE) _up
+	$(symfony) proxy:start
 	@echo
 	@$(call message_success, You can now run the Symfony server)
 	@echo


### PR DESCRIPTION
Le serveur proxy de Symfony ne se lançant pas automatiquement au démarrage de la machine, il faut penser à le lancer si on souhaite accéder au projet (sinon on a une erreur DNS).

Je fais maintenant en sorte de le lancer au `make up`.