### PR TITLE
chore(docker-compose): support for docker compose v2

### DIFF
--- a/noshow.app-docker/.manala/Makefile.tmpl
+++ b/noshow.app-docker/.manala/Makefile.tmpl
@@ -18,7 +18,7 @@ include $(_ROOT_DIR)/.manala/make/git.mk
 user := $(shell id -u)
 group := $(shell id -g)
 
-dc := USER_ID=$(user) GROUP_ID=$(group) docker-compose
+dc := USER_ID=$(user) GROUP_ID=$(group) $(shell docker compose > /dev/null 2>&1 && echo 'docker compose' || echo 'docker-compose')
 sail := ./sail
 
 HELP += $(call help_section, Environment)

--- a/noshow.app-docker/README.md
+++ b/noshow.app-docker/README.md
@@ -7,7 +7,7 @@ A [Manala recipe](https://github.com/manala/manala-recipes) for projects using t
 ## Requirements
 
 * [manala](https://manala.github.io/manala/)
-* [Docker Desktop 2.2.0+](https://docs.docker.com/engine/install/)
+* [Docker Desktop 2.2.0+](https://docs.docker.com/engine/install/), with [Docker Compose](https://docs.docker.com/compose/install/) **or** [Docker Compose v2 plugin](https://docs.docker.com/compose/cli-command/#install-on-linux)
 
 ## Init
 

--- a/yprox.app-docker/.manala/Makefile.tmpl
+++ b/yprox.app-docker/.manala/Makefile.tmpl
@@ -21,7 +21,7 @@ include $(_ROOT_DIR)/.manala/make/git.mk
 user := $(shell id -u)
 group := $(shell id -g)
 
-dc := USER_ID=$(user) GROUP_ID=$(group) docker-compose
+dc := USER_ID=$(user) GROUP_ID=$(group) $(shell docker compose > /dev/null 2>&1 && echo 'docker compose' || echo 'docker-compose')
 symfony := symfony
 php := $(symfony) php
 composer := $(symfony) composer

--- a/yprox.app-docker/README.md
+++ b/yprox.app-docker/README.md
@@ -7,7 +7,7 @@ A [Manala recipe](https://github.com/manala/manala-recipes) for projects using t
 ## Requirements
 
 * [manala](https://manala.github.io/manala/)
-* [Docker Desktop 2.2.0+](https://docs.docker.com/engine/install/)
+* [Docker Desktop 2.2.0+](https://docs.docker.com/engine/install/), with [Docker Compose](https://docs.docker.com/compose/install/) **or** [Docker Compose v2 plugin](https://docs.docker.com/compose/cli-command/#install-on-linux)
 * Symfony CLI (with [local proxy support](https://symfony.com/doc/current/setup/symfony_server.html#setting-up-the-local-proxy)), PHP and Node.js must be installed by yourself on your machine
 
 ## Init


### PR DESCRIPTION
Ajout du support de [Docker Compose v2](https://docs.docker.com/compose/cli-command/) (`docker-compose` est droppé au profit de `docker compose`, plugin intégré au CLI Docker).