### PR TITLE
fix(yprox.sylius): in composer v2.7 plugins are not executed when super user run the command

### DIFF
--- a/yprox.sylius/.docker/Dockerfile
+++ b/yprox.sylius/.docker/Dockerfile
@@ -12,6 +12,7 @@ ARG COMPOSER_AUTH
 COPY . .
 
 # Install composer
+ENV COMPOSER_ALLOW_SUPERUSER=1
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 RUN composer install --no-scripts
 


### PR DESCRIPTION
OPS-920
