### PR TITLE
fix(yprox.app-docker): add PostgreSQL 14/16/18 and make minio bucket_name nullable

### DIFF
--- a/yprox.app-docker/.manala.yaml
+++ b/yprox.app-docker/.manala.yaml
@@ -36,7 +36,7 @@ system:
         init: ~
     postgresql:
         # @option {"label": "PostgreSQL version"}
-        # @schema {"enum": [null, 13, 12, 11, 10, 9.6]}
+        # @schema {"enum": [null, 18, 16, 14, 13, 12, 11, 10, 9.6]}
         version: ~
     redis:
         # @option {"label": "Redis version"}
@@ -63,5 +63,5 @@ system:
         # @schema {"enum": [null, "*"]}
         version: ~
         # @option {"label": "Bucket name (in kebab-case)"}
-        # @schema {"type": "string"}
+        # @schema {"type": ["string", "null"]}
         bucket_name: ~


### PR DESCRIPTION
Deux corrections d'une ligne chacune dans `yprox.app-docker/.manala.yaml`.

## 1. PostgreSQL 14, 16 et 18

Les seules versions proposées étaient `13, 12, 11, 10, 9.6` — **toutes EOL**, la 13 depuis novembre 2025.

```diff
-        # @schema {"enum": [null, 13, 12, 11, 10, 9.6]}
+        # @schema {"enum": [null, 18, 16, 14, 13, 12, 11, 10, 9.6]}
```

Les anciennes versions sont conservées pour ne casser aucun projet existant. Les trois ajoutées disposent bien d'une image officielle `-alpine` (vérifié sur le Docker Hub), ce qu'attend `docker-compose.yaml.tmpl` via `postgres:{{ $postgresql.version }}-alpine`.

## 2. `minio.bucket_name` bloquait `manala up`

`bucket_name` était déclaré `{"type": "string"}` — non nullable — avec un défaut `~`. Comme manala valide le manifeste fusionné, **tout projet n'utilisant pas minio échouait** :

```
⨯ invalid project manifest vars                    file=.manala.yaml
  ⨯ invalid type                                   expected=string given=null
```

```diff
-        # @schema {"type": "string"}
+        # @schema {"type": ["string", "null"]}
```

C'est aligné sur `mariadb.init` et `mysql.init`, qui utilisent déjà `["string", "null"]`. Aucun effet fonctionnel : les services minio sont conditionnés à `minio.version`, pas à `bucket_name`.

## Vérification

Testé depuis un vrai projet (`symfony-app-template`) avec `manala up --repository <clone local>` :

| Version demandée | Résultat |
|---|---|
| 18 | accepté → `postgres:18-alpine` |
| 16 | accepté → `postgres:16-alpine` |
| 14 | accepté → `postgres:14-alpine` |
| 15 | refusé (volontairement absent de l'enum) |
| 12 | toujours accepté |

`manala up` passe désormais sans avoir à déclarer un `minio.bucket_name` factice. L'application a ensuite été validée de bout en bout contre `postgres:18-alpine` : `doctrine:schema:update`, `schema:validate` en sync, fixtures et suite PHPUnit.

## Hors périmètre

`yprox.app` expose le même enum PostgreSQL, mais l'installe via Ansible : les versions réellement supportées dépendent de la collection `manala.roles` (non épinglée dans `collections/requirements.yaml`) et de la box Debian. Je n'ai pas pu le vérifier, donc je ne l'ai pas touché — à traiter séparément si besoin.

## Dépendance

https://github.com/Yproximite/symfony-app-template/pull/2320 attend cette PR : son `manala up` génère un `postgresql.version: 18` que la recette actuelle rejetterait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)