### PR TITLE
fix(yprox.app-docker): do not let "server:ca:install" abort the integration setup

### DIFF
--- a/yprox.app-docker/.manala/Makefile.tmpl
+++ b/yprox.app-docker/.manala/Makefile.tmpl
@@ -55,7 +55,11 @@ setup-symfony:
 	$(MAKE) setup-domain
 
 setup-symfony@integration:
-	$(symfony) server:ca:install
+	# The CA is installed in the system trust store, which is all "symfony serve"
+	# needs, even when no Firefox/Chrome NSS database is found. The CLI still exits
+	# non-zero in that case, which is the norm on a bare CI runner. Keep going, but
+	# let make report the ignored error so a real failure stays visible.
+	-$(symfony) server:ca:install
 
 setup-domain:
 	$(symfony) proxy:domain:attach {{ .Vars.system.app_name }}


### PR DESCRIPTION
`make setup@integration` échoue sur **sa toute première commande**, ce qui rend la CI inutilisable pour tout projet basé sur cette recette.

## Symptôme

```
symfony server:ca:install
  failed to install the local Certificate Authority: no Firefox and/or Chrome/Chromium security databases found
The local CA is now installed in the system trust store!
make: *** [.manala/Makefile:49: setup-symfony@integration] Error 1
```

Le CA **est bien installé** dans le trust store système — le seul dont `symfony serve` a besoin. La CLI Symfony (5.17.1) renvoie malgré tout un code non nul parce qu'elle ne trouve aucune base NSS de navigateur, ce qui est le cas normal sur un runner CI nu. `make` s'arrête donc immédiatement, et le pipeline n'atteint jamais `_up`, l'installation des dépendances ni les tests.

Aucune option de la CLI ne permet de tolérer ce cas : `server:ca:install` n'accepte que `--renew` et `--force`.

## Correctif

```diff
 setup-symfony@integration:
-	$(symfony) server:ca:install
+	# The CA is installed in the system trust store, which is all "symfony serve"
+	# needs, even when no Firefox/Chrome NSS database is found. The CLI still exits
+	# non-zero in that case, which is the norm on a bare CI runner. Keep going, but
+	# let make report the ignored error so a real failure stays visible.
+	-$(symfony) server:ca:install
```

Deux choix délibérés :

- **Seule la cible `@integration` est rendue tolérante.** `setup-symfony`, utilisée en poste de dev où un navigateur est présent, continue d'échouer franchement.
- **Préfixe `-` plutôt que `|| true`.** make journalise `Error 1 (ignored)` : une vraie panne d'installation du CA reste visible dans les logs au lieu d'être silencieusement avalée.

## Vérification

Recette régénérée sur un projet réel, puis commande forcée en échec via `symfony=false` :

| Cible | Résultat |
|---|---|
| `make setup-symfony@integration symfony=false` | **exit 0**, `make: [.manala/Makefile:53: setup-symfony@integration] Error 1 (ignored)` |
| `make setup-symfony symfony=false` | **exit 2**, `make: *** [.manala/Makefile:44: setup-symfony] Error 1` |

Le comportement asymétrique recherché est bien obtenu.

## Contexte

Découvert en montant `symfony-app-template` vers Symfony 7.4 / PHP 8.5 (Yproximite/symfony-app-template#2320) : les trois jobs de la CI — `php`, `javascript` et `cypress` — mouraient tous ici, avant même d'atteindre le correctif Docker Compose v2 apporté par #51. Ce n'était donc pas une régression de cette montée de version, mais un blocage préexistant que rien n'atteignait.

Une fois cette PR mergée, les projets concernés doivent relancer `manala up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)