### PR TITLE
fix(yprox.app-docker): mount the PostgreSQL volume where 18+ expects it

### DIFF
--- a/yprox.app-docker/docker-compose.yaml.tmpl
+++ b/yprox.app-docker/docker-compose.yaml.tmpl
@@ -48,7 +48,18 @@ services:
       TZ: {{ .Vars.system.timezone }}
       PGTZ: {{ .Vars.system.timezone }}
     volumes:
+      {{- /*
+        From 18 on, the official image stores data under a major-version-specific
+        directory and refuses to start against a mount at /var/lib/postgresql/data:
+        "in 18+, these Docker images are configured to store database data in a
+        format which is compatible with pg_ctlcluster". The upstream advice is a
+        single mount one level up.
+      */}}
+      {{- if ge (float64 $postgresql.version) 18.0 }}
+      - db-data:/var/lib/postgresql
+      {{- else }}
       - db-data:/var/lib/postgresql/data
+      {{- end }}
     healthcheck:
       test: pg_isready
       interval: 10s


### PR DESCRIPTION
Correctif de #51, qui a ajouté PostgreSQL 18 à l'enum sans que le montage de volume suive.

## Le symptôme

Le conteneur démarre, se déclare *healthy* pendant l'`initdb`, puis **sort en 1** :

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).

       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)

       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql
```

Rien en aval ne s'en aperçoit tout de suite. La boucle d'attente du healthcheck dans `_up` passe, puis le conteneur meurt. Le premier à trébucher est le CLI Symfony, qui n'injecte plus `DATABASE_URL` — d'où un `composer install` qui échoue dans `cache:clear` :

```
In EnvVarProcessor.php line 221:
  Environment variable not found: "DATABASE_URL".
```

Diagnostic peu évident, puisque l'erreur remonte à trois étapes de sa cause.

## Le correctif

Le montage suit désormais la version, 17 et antérieures restant inchangées :

```gotemplate
{{- if ge (float64 $postgresql.version) 18.0 }}
- db-data:/var/lib/postgresql
{{- else }}
- db-data:/var/lib/postgresql/data
{{- end }}
```

## Vérification

Régénéré sur un vrai projet en 18, 16, 12 et 9.6 : seule la 18 obtient `/var/lib/postgresql`, les autres gardent `/var/lib/postgresql/data`.

Avec ce montage, le conteneur **reste debout** et le CLI distribue à nouveau la variable :

```
DATABASE_URL=[postgres://app:app@127.0.0.1:53929/app?sslmode=disable&charset=utf8&serverVersion=18.4]
```

là où il ne distribuait rien. La suite passe ensuite de bout en bout : `cache:clear`, `doctrine:database:create`, `schema:update`, `fixtures:load`, puis PHPUnit.

## Pourquoi #51 ne l'a pas vu

La vérification d'alors lançait `docker run postgres:18-alpine` **sans aucun volume** — exactement le cas qui fonctionne. Le problème n'apparaît qu'avec le montage que génère ce template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)