### PR TITLE
ci(yprox.wordpress): passer Dependabot à l'auto-merge natif de GitHub

### DIFF
--- a/yprox.wordpress/.github/auto-merge.yml
+++ b/yprox.wordpress/.github/auto-merge.yml
@@ -1,9 +1,0 @@
-# Documentation: https://github.com/ahmadnassri/action-dependabot-auto-merge#configuration-file-syntax
-
-- match:
-      dependency_type: development
-      update_type: semver:minor # includes patch updates!
-
-- match:
-      dependency_type: production
-      update_type: semver:minor # includes patch updates!

--- a/yprox.wordpress/.github/workflows/ci.yml.tmpl
+++ b/yprox.wordpress/.github/workflows/ci.yml.tmpl
@@ -111,10 +111,58 @@ jobs:
     runs-on: ubuntu-latest
     needs: [php, javascript]
     if: {{"${{ github.actor == 'dependabot[bot]' }}"}}
+    permissions:
+      contents: write
+      pull-requests: write
+      security-events: read # required by "alert-lookup" below
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
         with:
-          github-token: {{"${{ secrets.ACTION_DEPENDABOT_AUTO_MERGE_TOKEN }}"}}
+          # Populates "ghsa-id", which tells a security fix apart from a
+          # regular version bump.
+          alert-lookup: true
+
+      # Development dependencies: any minor or patch.
+      # Production dependencies: security fixes only, minor or patch.
+      # Anything else (major, indirect dependencies) is merged by hand.
+      #
+      # Production is restricted because the composer "require" of a WordPress
+      # project holds the core and the plugins, which do not follow semver, and
+      # this CI only validates, lints and builds: nothing tests the site.
+      - name: Apply auto-merge policy
+        id: policy
+        env:
+          DEPENDENCY_TYPE: {{"${{ steps.metadata.outputs.dependency-type }}"}}
+          UPDATE_TYPE: {{"${{ steps.metadata.outputs.update-type }}"}}
+          GHSA_ID: {{"${{ steps.metadata.outputs.ghsa-id }}"}}
+        run: |
+          eligible=false
+
+          case "$UPDATE_TYPE" in
+              version-update:semver-minor | version-update:semver-patch)
+                  case "$DEPENDENCY_TYPE" in
+                      direct:development)
+                          eligible=true
+                          ;;
+                      direct:production)
+                          if [ -n "$GHSA_ID" ]; then eligible=true; fi
+                          ;;
+                  esac
+                  ;;
+          esac
+
+          echo "eligible=$eligible" >>"$GITHUB_OUTPUT"
+          echo "$DEPENDENCY_TYPE / $UPDATE_TYPE / security=${GHSA_ID:-no} -> auto-merge: $eligible"
+
+      # The PAT is required to approve: the Actions GITHUB_TOKEN is not
+      # allowed to approve a pull request.
+      - name: Approve and enable auto-merge
+        if: {{"${{ steps.policy.outputs.eligible == 'true' }}"}}
+        env:
+          GH_TOKEN: {{"${{ secrets.ACTION_DEPENDABOT_AUTO_MERGE_TOKEN }}"}}
+          PR_URL: {{"${{ github.event.pull_request.html_url }}"}}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/yprox.wordpress/.manala.yaml
+++ b/yprox.wordpress/.manala.yaml
@@ -7,7 +7,6 @@ manala:
         - .github/workflows/cd.yml.tmpl
         - .github/workflows/composer_operations.yml
         - .github/workflows/manala_sync.yml
-        - .github/auto-merge.yml
         - .dockerignore
         - docker-compose.yaml.tmpl
         - Procfile.tmpl


### PR DESCRIPTION
L'auto-merge Dependabot est mort dans tous les projets issus de `yprox.wordpress`. `ahmadnassri/action-dependabot-auto-merge` ne merge pas lui-même : il approuve la PR avec un corps de revue valant `@dependabot merge`, et délègue à Dependabot. Or GitHub ne lit plus les commandes dans le corps d'une revue, et l'action n'a plus eu de release depuis décembre 2022.

Constaté sur `refonte-yproximite-2026` : 26 PR Dependabot ouvertes, aucune jamais mergée. Sur sa PR #71, le job conclut `production:semver:minor detected, will auto-merge`, la revue est bien posée sous le compte du PAT — et rien ne bouge depuis le 1er juillet.

Même correctif que sur `portfolio-yproximite` (9ebaf62) et `yProx` (08721be34e) : `dependabot/fetch-metadata` puis `gh pr merge --auto`, qui survit aux rebases.

## Politique

| dépendance | minor / patch | major | indirecte |
| --- | --- | --- | --- |
| développement | auto-merge | manuel | manuel |
| production | auto-merge si correctif de sécurité | manuel | manuel |

**C'est un retour en arrière sur dc8af3f**, qui avait ouvert l'auto-merge à tout minor ou patch de production en décembre 2024. Deux raisons propres à WordPress : le `require` de `composer.json` tient le core et les plugins, qui ne suivent pas semver — un « minor » chez un plugin peut être une refonte — et la CI de cette recette se limite à valider, linter et builder, aucun test ne couvre le site. Si ce point avait déjà été pesé à l'époque et que le choix était assumé, dites-le : la partie mécanisme de cette PR tient sans ce changement de politique.

## `auto-merge.yml`

Retiré de la recette **et** de la liste `manala.sync` : la politique vit désormais dans le workflow. Le laisser dans `manala.sync` sans le fichier fait échouer `manala update` avec `no source file or directory`, les deux gestes vont ensemble.

Les projets déjà initialisés gardent une copie inerte du fichier — `manala update` ne supprime pas un fichier sorti de la recette. À nettoyer projet par projet.

## Vérifié en local

`manala update` (0.18.2) lancé sur une copie de `refonte-yproximite-2026` avec cette recette :

- le `ci.yml` rendu est exactement celui de la PR Yproximite/refonte-yproximite-2026#74 ;
- l'update ne signale plus d'erreur après le retrait de `manala.sync` ;
- `.github/dependabot.yml` n'étant pas dans `manala.sync`, les réglages locaux des projets (`open-pull-requests-limit`) restent intacts.

## Reste à faire, hors périmètre de cette PR

- Chaque dépôt doit activer `allow_auto_merge`, sans quoi `gh pr merge --auto` échoue. Fait sur `refonte-yproximite-2026`.
- `yprox.sylius/.github/workflows/ci.yml` porte le même montage mort (lignes 94-104), sans `auto-merge.yml` — l'action y tourne donc avec sa politique par défaut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
