### PR TITLE
ci(yprox.wordpress): donner à fetch-metadata un jeton qui lit les alertes

### DIFF
--- a/yprox.wordpress/.github/workflows/ci.yml.tmpl
+++ b/yprox.wordpress/.github/workflows/ci.yml.tmpl
@@ -123,6 +123,9 @@ jobs:
           # Populates "ghsa-id", which tells a security fix apart from a
           # regular version bump.
           alert-lookup: true
+          # "alert-lookup" queries the repository security alerts, which the
+          # default token cannot read on a Dependabot pull request.
+          github-token: {{"${{ secrets.ACTION_DEPENDABOT_AUTO_MERGE_TOKEN }}"}}
 
       # Development dependencies: any minor or patch.
       # Production dependencies: security fixes only, minor or patch.


### PR DESCRIPTION
Suite de #54. Le mécanisme d'auto-merge fonctionne, mais sa branche « production » ne se déclenche jamais : `ghsa-id` sort toujours vide, donc un correctif de sécurité sur une dépendance de production attend une relecture au lieu de partir.

`alert-lookup` interroge les alertes de sécurité du dépôt. Sans `github-token`, l'action se rabat sur `github.token` — plafonné en lecture seule sur une pull request Dependabot, et incapable de lire ces alertes.

## Constaté

`refonte-yproximite-2026`, PR #64 : `postcss 8.5.10 → 8.5.16`, avec trois alertes ouvertes sur 8.5.10 (`GHSA-6g55-p6wh-862q`, `GHSA-r28c-9q8g-f849`, `GHSA-fxqj-rqcc-2cmp`).

```
DEPENDENCY_TYPE: direct:production
UPDATE_TYPE: version-update:semver-patch
GHSA_ID:
direct:production / version-update:semver-patch / security=no -> auto-merge: false
```

`screenshot-function`, qui tourne avec ce montage depuis le 13 août, passe ce jeton — et ses PR se mergent. C'est la seule différence entre les deux workflows.

Le PAT est déjà utilisé par l'étape d'approbation et déjà résolu en contexte Dependabot : l'ancienne action `ahmadnassri` s'en servait pour approuver depuis ce même contexte.

## Ce que ce correctif ne garantit pas encore

Le code de l'action compare `vulnerableRequirements` à `` `= ${version}` ``, or l'API GraphQL ne renvoie pas toujours ce format :

```
refonte-yproximite-2026   NPM      | postcss               | req=8.5.10     ← nu
portfolio-yproximite      COMPOSER | symfony/security-core | req== 5.2.7    ← "= 5.2.7"
portfolio-yproximite      NPM      | dns-packet            | req== 1.3.1    ← "= 1.3.1"
```

Appliqué aux alertes réelles de `refonte-yproximite-2026`, le prédicat de l'action renvoie 0 alerte ; le même prédicat sans le préfixe `= ` en renvoie 3, exactement celles attendues.

Ce commit lève donc la cause certaine (le jeton). Si `ghsa-id` reste vide après merge, c'est le format qui bloque, et il faudra remplacer `alert-lookup` par une lecture directe de l'API des alertes — ce qui permettrait au passage de vérifier que la version cible atteint bien `first_patched_version`, ce que `alert-lookup` ne fait pas.

## Vérification

`manala update` (0.18.2) sur une copie de `refonte-yproximite-2026` : le rendu ajoute exactement les trois lignes attendues, et rien d'autre. La PR de rendu côté projet est Yproximite/refonte-yproximite-2026#75.

Le test décisif suivra : `@dependabot rebase` sur la PR #64, qui est le cas nominal.

## Hors périmètre

`portfolio-yproximite` et `yProx` portent la même omission, à traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
