### PR TITLE
ci(yprox.wordpress): lire les alertes nous-mêmes et ouvrir aux dépendances indirectes

### DIFF
--- a/yprox.wordpress/.github/workflows/ci.yml.tmpl
+++ b/yprox.wordpress/.github/workflows/ci.yml.tmpl
@@ -114,29 +114,67 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      security-events: read # required by "alert-lookup" below
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v3
-        with:
-          # Populates "ghsa-id", which tells a security fix apart from a
-          # regular version bump.
-          alert-lookup: true
+
+      # The action's own "alert-lookup" cannot be used: it matches alerts whose
+      # "vulnerableRequirements" reads "= <version>", while the API returns the
+      # bare version for lockfile alerts, so it never finds anything. Querying
+      # the alerts here also lets us require that the target version actually
+      # reaches the patched one, which "alert-lookup" never checks.
+      - name: Look up security advisories
+        id: advisory
+        env:
+          GH_TOKEN: {{"${{ secrets.ACTION_DEPENDABOT_AUTO_MERGE_TOKEN }}"}}
+          DEPENDENCY_NAMES: {{"${{ steps.metadata.outputs.dependency-names }}"}}
+          PREVIOUS_VERSION: {{"${{ steps.metadata.outputs.previous-version }}"}}
+          NEW_VERSION: {{"${{ steps.metadata.outputs.new-version }}"}}
+        run: |
+          alerts=$(gh api graphql \
+              -F owner="${GITHUB_REPOSITORY%/*}" -F name="${GITHUB_REPOSITORY#*/}" \
+              -f query='
+                query($owner: String!, $name: String!) {
+                  repository(owner: $owner, name: $name) {
+                    vulnerabilityAlerts(first: 100, states: OPEN) { nodes {
+                      vulnerableRequirements
+                      securityVulnerability { package { name } firstPatchedVersion { identifier } }
+                      securityAdvisory { ghsaId severity } } } } }' \
+            | jq -r --arg names "$DEPENDENCY_NAMES" --arg prev "$PREVIOUS_VERSION" '
+                ($names | split(",") | map(gsub("^\\s+|\\s+$"; ""))) as $deps
+                | .data.repository.vulnerabilityAlerts.nodes[]
+                | select(.securityVulnerability.package.name as $n | $deps | index($n))
+                | select((.vulnerableRequirements | ltrimstr("= ")) == $prev)
+                | "\(.securityAdvisory.ghsaId) \(.securityVulnerability.firstPatchedVersion.identifier // "") \(.securityAdvisory.severity)"')
+
+          ghsa=""
+          while read -r id patched severity; do
+              [ -z "$patched" ] && continue
+              # Skip advisories the target version does not actually fix.
+              [ "$(printf '%s\n%s\n' "$patched" "$NEW_VERSION" | sort -V | head -n1)" = "$patched" ] || continue
+              ghsa="$id"
+              echo "$id ($severity), fixed in $patched"
+              break
+          done <<<"$alerts"
+
+          echo "ghsa-id=$ghsa" >>"$GITHUB_OUTPUT"
 
       # Development dependencies: any minor or patch.
-      # Production dependencies: security fixes only, minor or patch.
-      # Anything else (major, indirect dependencies) is merged by hand.
+      # Production and indirect dependencies: security fixes only, minor or patch.
+      # Majors are merged by hand.
       #
       # Production is restricted because the composer "require" of a WordPress
       # project holds the core and the plugins, which do not follow semver, and
       # this CI only validates, lints and builds: nothing tests the site.
+      # Indirect dependencies carry almost every advisory of an npm project, so
+      # excluding them would leave the security policy with nothing to act on.
       - name: Apply auto-merge policy
         id: policy
         env:
           DEPENDENCY_TYPE: {{"${{ steps.metadata.outputs.dependency-type }}"}}
           UPDATE_TYPE: {{"${{ steps.metadata.outputs.update-type }}"}}
-          GHSA_ID: {{"${{ steps.metadata.outputs.ghsa-id }}"}}
+          GHSA_ID: {{"${{ steps.advisory.outputs.ghsa-id }}"}}
         run: |
           eligible=false
 
@@ -146,7 +184,7 @@ jobs:
                       direct:development)
                           eligible=true
                           ;;
-                      direct:production)
+                      direct:production | indirect)
                           if [ -n "$GHSA_ID" ]; then eligible=true; fi
                           ;;
                   esac


### PR DESCRIPTION
**Remplace #55**, qui ajoutait un PAT à `alert-lookup` : le test a montré que ça ne suffit pas. À fermer sans merger.

Deux corrections qui n'ont d'intérêt qu'ensemble : la politique de sécurité ne s'appuyait sur rien, et ne visait presque rien.

## `alert-lookup` est inexploitable

L'action retient une alerte dont `vulnerableRequirements` vaut `= <version>`, or l'API renvoie la version nue pour les alertes issues d'un lockfile :

```
refonte-yproximite-2026   NPM      | postcss               | req=8.5.10     ← nu
portfolio-yproximite      COMPOSER | symfony/security-core | req== 5.2.7    ← "= 5.2.7"
```

Le format n'est donc pas uniforme d'un dépôt à l'autre : l'action est fiable par endroits et muette ailleurs, sans que rien ne le signale. Sur `refonte-yproximite-2026`, son prédicat appliqué aux alertes réelles n'en retient aucune ; le même prédicat sans le préfixe en retient trois.

Passer un PAT ne change rien — vérifié sur la PR #64, `github-token` en place :

```
DEPENDENCY_TYPE: direct:production
GHSA_ID:
direct:production / version-update:semver-patch / security=no -> auto-merge: false
```

L'étape interroge donc les alertes directement, et compare la version installée après avoir retiré un éventuel `= `.

Elle vérifie en prime que la version cible atteint réellement `firstPatchedVersion`, ce que `alert-lookup` ne fait pas : une PR peut porter une advisory sans clore la vulnérabilité. Sur #64, `postcss 8.5.10 → 8.5.16` corrige `GHSA-6g55-p6wh-862q` (corrigé en 8.5.12) mais laisse deux advisories ouvertes.

## Les indirectes rejoignent la production

Sur ce dépôt, **21 des 23 paquets porteurs d'une alerte sont transitifs** — `brace-expansion`, `nanoid`, `js-yaml`, `ws`, `svgo`, `qs`, `shell-quote`… Les exclure laissait à la politique de sécurité 2 paquets sur 23, autant dire rien.

Une transitive n'est ni le core WordPress ni un plugin, c'est une brique tirée par webpack ou babel. Le garde-fou reste entier : sans advisory réellement corrigée, pas d'auto-merge.

| dépendance | minor / patch | avec advisory corrigée | major |
| --- | --- | --- | --- |
| développement | auto-merge | auto-merge | manuel |
| production | manuel | auto-merge | manuel |
| indirecte | manuel | auto-merge | manuel |

## Vérifications

L'étape **telle que rendue par `manala update`** a été exécutée contre l'API du dépôt :

```
postcss                8.5.10  -> 8.5.16   | GHSA-6g55-p6wh-862q (HIGH), fixed in 8.5.12
shell-quote            1.8.3   -> 1.10.0   | GHSA-w7jw-789q-3m8p (CRITICAL), fixed in 1.8.4
nanoid                 3.3.11  -> 3.3.18   | GHSA-28wg-ghj8-5hjv (HIGH), fixed in 3.3.16
ws                     8.20.0  -> 8.21.0   | GHSA-58qx-3vcg-4xpx (MODERATE), fixed in 8.20.1
http-proxy-middleware  2.0.9   -> 2.0.10   | GHSA-64mm-vxmg-q3vj (MODERATE), fixed in 2.0.10
postcss                8.5.10  -> 8.5.10   | <aucune advisory>
lenis                  1.3.23  -> 1.3.26   | <aucune advisory>
three                  0.184.0 -> 0.185.1  | <aucune advisory>
webpack                5.106.2 -> 5.109.2  | <aucune advisory>
tailwindcss            4.2.2   -> 4.3.2    | <aucune advisory>
```

Le cas `postcss 8.5.10 → 8.5.10` est le piège que filtre le rapprochement sur la version installée : deux instances de `postcss` coexistent dans `yarn.lock` (7.0.39 et 8.5.10), et une advisory portant sur l'une ne doit pas valider une PR qui met à jour l'autre.

Simulée sur les 27 PR ouvertes du dépôt, la politique en retient **9, dont 8 correctifs de sécurité** (1 critical, 5 high). Les refus sont les majors, et `lenis` / `three` / `tailwindcss` en production sans advisory.

YAML validé, et `bash -n` sur les trois scripts du job.

## Hors périmètre

`portfolio-yproximite` et `yProx` utilisent le même `alert-lookup` et la même politique sans les indirectes. Leur format d'alertes étant partiellement en `= x.y.z`, leur comportement est mixte plutôt que muet — à traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
