### PR TITLE
feat(yprox.wordpress): autoriser Node 22

### DIFF
--- a/yprox.wordpress/.manala.yaml
+++ b/yprox.wordpress/.manala.yaml
@@ -32,7 +32,7 @@ system:
         config: {}
     node:
         # @option {"label": "Node version"}
-        # @schema {"enum": [null,"10.24.1","18.20.8","20.20.0"]}
+        # @schema {"enum": [null,"10.24.1","18.20.8","20.20.0","22.23.2"]}
         version: 10.24.1
         # @schema {"type": ["array"]}
         extensions: []

--- a/yprox.wordpress/.manala.yaml.tmpl
+++ b/yprox.wordpress/.manala.yaml.tmpl
@@ -21,6 +21,12 @@ system:
         version: {{ .php.version | toYaml }}
         extensions: {{ .php.extensions | toYaml }}
 
+    {{- if .node.version }}
+    node:
+        version: {{ .node.version | toYaml }}
+        extensions: {{ .node.extensions | toYaml }}
+    {{- end }}
+
     run:
         postdeploy: {{ .run.postdeploy | toYaml }}
 


### PR DESCRIPTION
L'enum de `system.node.version` s'arrêtait à `20.20.0`. Ajout de `22.23.2`, la dernière LTS Jod.

Motivation : `sass` exige `node >= 20.19.0` depuis sa `1.100.0`. Un projet qui le tire en transitif ne peut donc plus installer ses dépendances sous Node 18, ni en CI ni dans le stage `builder` du Dockerfile. L'enum n'offrait plus de cible LTS supportée.

## Bloc `node:` manquant à l'init

`.manala.yaml.tmpl` n'émettait pas le bloc `node:` pourtant défini par le schéma : un `manala init` produisait un manifeste sans `system.node.version`, retombant en silence sur le défaut `10.24.1`. Le bloc est gardé par `{{- if .node.version }}`, sur le même modèle que `redis`.

Sans effet sur `manala up` : `.manala.yaml` n'est pas dans la liste `sync:`, c'est l'entrée et non la sortie.

## Vérification

`manala up --repository <local>` sur un projet passé à `node.version: 22.23.2`, puis pipeline complet sur cette version : `yarn install` (sans `--ignore-engines`), `yarn lint` et `yarn build` passent.

À noter pour les projets consommateurs : `package.json` `engines.node` doit être bumpé dans le même commit que `.manala.yaml`, sinon `yarn` refuse l'install en CI comme dans le build Docker.