### PR TITLE
chore(yprox.wordpress): passer Composer de 2.6 à 2.10

### DIFF
--- a/yprox.wordpress/.docker/Dockerfile.tmpl
+++ b/yprox.wordpress/.docker/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-ARG COMPOSER_VERSION=2.6
+ARG COMPOSER_VERSION=2.10
 FROM composer:${COMPOSER_VERSION} as composer-local
 
 FROM rg.fr-par.scw.cloud/yproximite/wordpress-base:{{ .Vars.system.php.version }} as base


### PR DESCRIPTION
Le tag `composer` du Dockerfile était épinglé sur `2.6` depuis 2023 et n'avait pas bougé depuis.

## Compatibilité

Composer 2.10 requiert `php ^7.2.5 || ^8.0`, donc compatible avec toutes les versions proposées par le recipe (7.4 au minimum).

Le Dockerfile ne copie que le binaire `/usr/bin/composer` depuis l'image `composer` : c'est le PHP de `wordpress-base` qui l'exécute, la version de PHP embarquée dans l'image `composer` n'entre pas en jeu.

## Cohérence avec le CI

Le CI installe `composer:v2` (`ci.yml.tmpl`), soit la dernière v2 disponible. Les projets validaient donc leur `composer.lock` avec une version plus récente que celle utilisée pour construire leur image.

## Notes

- `COMPOSER_VERSION` reste un `ARG` : un projet peut surcharger la valeur au build si besoin.
- Le tag `2.10` suit la mineure : les correctifs de patch seront pris sans nouvelle modification du recipe.
- Composer 2.10 valide les noms de paquets issus de la résolution avant installation et échoue si l'un d'eux n'est pas un `vendor/package` valide. Un premier build peut donc signaler une dépendance que 2.6 acceptait silencieusement.
- La prise en compte se fait projet par projet, au `manala update`.
