### PR TITLE
ci(yprox.wordpress): valider les PR de workflow et monter les actions

### DIFF
--- a/yprox.wordpress/.github/workflows/ci.yml.tmpl
+++ b/yprox.wordpress/.github/workflows/ci.yml.tmpl
@@ -1,5 +1,9 @@
 name: CI
 
+# The push and pull_request filters differ on purpose, do not align them.
+# Workflow files never ship in the image, so push keeps ignoring them. On
+# pull_request they still need the checks to run, otherwise such a pull request
+# cannot be validated. Only ci.yml is opted back in.
 on:
   push:
     branches:
@@ -7,8 +11,10 @@ on:
     paths-ignore:
       - ".github/**"
   pull_request:
-    paths-ignore:
-      - ".github/**"
+    paths:
+      - "**"
+      - "!.github/**"
+      - ".github/workflows/ci.yml"
     types:
       - opened
       - reopened
@@ -32,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check composer.json existence
         run: echo "composer_exist=$(test -f composer.json && echo 'true' || echo 'false')" >> $GITHUB_ENV
@@ -50,14 +56,14 @@ jobs:
       - run: composer validate
         if: env.composer_exist == 'true'
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: {{"${{ env.COMPOSER_CACHE_DIR }}"}}
           key: {{"${{ runner.os }}"}}-composer-{{"${{ hashFiles('**/composer.lock') }}"}}
           restore-keys: {{"${{ runner.os }}"}}-composer-
         if: env.composer_exist == 'true'
 
-      - uses: ramsey/composer-install@v3
+      - uses: ramsey/composer-install@v4
         with:
           composer-options: "--prefer-dist --optimize-autoloader"
         if: env.composer_exist == 'true'
@@ -69,13 +75,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check package.json existence
         run: echo "package_exist=$(test -f package.json && echo 'true' || echo 'false')" >> $GITHUB_ENV
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: {{"${{ env.NODE_VERSION }}"}}
           cache: 'yarn'
@@ -96,7 +102,7 @@ jobs:
     if: {{"${{ github.actor == 'yprox' && contains(github.event.pull_request.labels.*.name, 'bifrost:composer_operation') }}"}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Merge pull requests
         uses: pascalgn/automerge-action@v0.16.4


### PR DESCRIPTION
## Filtres de déclenchement

Les filtres excluaient `.github/**` sur `push` comme sur `pull_request`. Sur `pull_request`, une PR ne touchant que des fichiers de workflow n'était donc jamais validée.

Les deux filtres sont désormais dissociés :

- `push` : inchangé
- `pull_request` : réintègre `.github/workflows/ci.yml`, et lui seul

`paths` et `paths-ignore` ne pouvant pas coexister sur un même événement, le filtre du `pull_request` est réécrit en `paths` avec exclusion puis réinclusion — l'ordre des motifs est significatif, le dernier qui correspond l'emporte.

Un commentaire en tête de fichier explique la différence entre les deux événements, pour éviter qu'elle soit alignée par la suite en la croyant accidentelle.

## Versions des actions

| Action | Avant | Après |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `actions/cache` | v4 | v6 |
| `ramsey/composer-install` | v3 | v4 |

`shivammathur/setup-php`, `dependabot/fetch-metadata` et `pascalgn/automerge-action` sont déjà à leur dernière version.

Ces majeures correspondent à des passages au runtime Node 24 et à des migrations ESM. Elles demandent un runner ≥ 2.327.1, ce que `ubuntu-latest` fournit.

Deux changements de comportement méritaient vérification :

- `setup-node` v5 puis v6 ont modifié la détection automatique du gestionnaire de paquets. Le recipe passe `cache: 'yarn'` explicitement, donc le cache reste honoré.
- `checkout` v7 restreint le checkout des PR de forks sous `pull_request_target` et `workflow_run`. Les trois `checkout` de ce fichier sont sur des jobs `push`/`pull_request`, hors périmètre.

À noter : `ramsey/composer-install` publie des branches `v1`…`v4` et non des tags.

## Vérification

Généré et appliqué sur un projet du parc, en PR : les jobs `php` et `javascript` se déclenchent et passent, les jobs d'auto-merge restent `skipped`. La prise en compte se fait projet par projet, au `manala update`.
